### PR TITLE
Including the main README

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,12 +1,10 @@
-.. Reg documentation master file, created by
-   sphinx-quickstart on Wed Sep 18 18:38:12 2013.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+.. include:: ../README.rst
 
-Welcome to Reg's documentation!
-===============================
 
-Contents:
+Welcome to Reg's documentation
+==============================
+
+Here's what we have:
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
The current main doc page is pretty bare. Including the README.rst is a trick I often use to:
- get a good intro for the main doc page
- make sure the readme is clear and small without cruft
