### PR TITLE
Add a default extractor function for ``match_class`` predicate

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,9 @@ CHANGES
 
 - Include doctests in Tox and Travis.
 
+- Have the ``match_class`` predicate use the class of the argument
+  with the given name by default.
+
 
 0.9.3 (2016-07-18)
 ==================

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -804,14 +804,13 @@ Here's what it looks like:
 
 .. testcode::
 
-  @reg.dispatch(reg.match_class('cls', lambda cls: cls))
+  @reg.dispatch(reg.match_class('cls'))
   def something(cls):
       raise NotImplementedError()
 
 Note the call to :func:`match_class` here. This lets us specify that
-we want to dispatch on the class, and we supply a lambda function that
-shows how to extract this from the arguments to ``something``; in this
-case we simply want the ``cls`` argument.
+we want to dispatch on the class, in this case we simply want the
+``cls`` argument.
 
 Let's use it:
 

--- a/reg/predicate.py
+++ b/reg/predicate.py
@@ -110,18 +110,22 @@ def match_argname(argname, fallback=None, default=None):
                            fallback, default)
 
 
-def match_class(name, func, fallback=None, default=None):
+def match_class(name, func=None, fallback=None, default=None):
     """Predicate that extracts class returned by func.
 
     :name: predicate name.
     :func: argument that takes arguments. These arguments are
       extracted from the arguments given to the dispatch function.
-      This function should return a class; dispatching is done
-      on this class.
+      This function should return a class; dispatching is done on this
+      class. If ``None`` use the class of the argument having the same
+      name as the predicate.
     :fallback: the fallback value. By default it is ``None``.
     :default: optional default value.
     :returns: a :class:`Predicate`.
+
     """
+    if func is None:
+        func = eval('lambda {0}: {0}'.format(name))
     return class_predicate(name, KeyExtractor(func), fallback, default)
 
 

--- a/reg/tests/test_classdispatch.py
+++ b/reg/tests/test_classdispatch.py
@@ -22,7 +22,7 @@ class Bar(object):
 
 
 def test_dispatch_basic():
-    @reg.dispatch(match_class('cls', lambda cls: cls))
+    @reg.dispatch(match_class('cls'))
     def something(cls):
         raise NotImplementedError()
 
@@ -41,7 +41,7 @@ def test_dispatch_basic():
 
 
 def test_classdispatch_multidispatch():
-    @reg.dispatch(match_class('cls', lambda cls: cls), 'other')
+    @reg.dispatch(match_class('cls'), 'other')
     def something(cls, other):
         raise NotImplementedError()
 
@@ -70,7 +70,7 @@ def test_classdispatch_multidispatch():
 
 
 def test_classdispatch_extra_arguments():
-    @reg.dispatch(match_class('cls', lambda cls: cls))
+    @reg.dispatch(match_class('cls'))
     def something(cls, extra):
         raise NotImplementedError()
 
@@ -99,7 +99,7 @@ def test_classdispatch_no_arguments():
 
 
 def test_classdispatch_override():
-    @reg.dispatch(match_class('cls', lambda cls: cls))
+    @reg.dispatch(match_class('cls'))
     def something(cls):
         raise NotImplementedError()
 


### PR DESCRIPTION
In most, if not all, the occurrences of the ``match_class`` predicate, its arguments are of the form

```
match_class('name', lambda name: name)
```

This PR adds a sensible default so that the lambda can be safely omitted, in a way that the previous invocation can be simplified to:

```
match_class('name')
```