### PR TITLE
Python support update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,10 @@ dist: xenial
 language: python
 
 python:
-    - "3.4"
-    - "3.5"
     - "3.6"
     - "3.7"
     - "3.8"
-    - "pypy3.6-7.1.1"
+    - "pypy3"
 matrix:
     include:
     - python: "3.7"

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ CHANGES
 0.13 (unreleased)
 =================
 
-- Nothing changed yet.
+- Drop support for Python below 3.6
 
 
 0.12 (2020-01-29)
@@ -21,7 +21,7 @@ CHANGES
   .. _#55: https://github.com/morepath/reg/issues/55
 
 - **Removed**: Removed support for Python 2.
-  
+
   You have to upgrade to Python 3 if you want to use this version.
 
 - Dropped support for Python 3.3.

--- a/reg/error.py
+++ b/reg/error.py
@@ -1,3 +1,2 @@
 class RegistrationError(Exception):
-    """Registration error.
-    """
+    """Registration error."""

--- a/reg/tests/test_dispatch.py
+++ b/reg/tests/test_dispatch.py
@@ -892,11 +892,17 @@ def test_fallback_should_already_use_subset():
     )
 
     assert (
-        view.by_args(Collection(), Request("", "POST", Item2()),).fallback
+        view.by_args(
+            Collection(),
+            Request("", "POST", Item2()),
+        ).fallback
         is body_model_fallback
     )
     assert (
-        view(Collection(), Request("", "POST", Item2()),)
+        view(
+            Collection(),
+            Request("", "POST", Item2()),
+        )
         == "Body model fallback"
     )
 

--- a/reg/tests/test_docgen.py
+++ b/reg/tests/test_docgen.py
@@ -5,7 +5,7 @@ from .fixtures.module import Foo, foo
 
 def rstrip_lines(s):
     "Delete trailing spaces from each line in s."
-    return "\n".join(l.rstrip() for l in s.splitlines())
+    return "\n".join(line.rstrip() for line in s.splitlines())
 
 
 def test_dispatch_method_class_help(capsys):

--- a/reg/tests/test_predicate.py
+++ b/reg/tests/test_predicate.py
@@ -60,7 +60,11 @@ def test_multi_class_predicate_permutations():
 
 
 def test_multi_key_predicate_permutations():
-    i = PredicateRegistry(match_key("a"), match_key("b"), match_key("c"),)
+    i = PredicateRegistry(
+        match_key("a"),
+        match_key("b"),
+        match_key("c"),
+    )
 
     assert list(i.permutations(["A", "B", "C"])) == [("A", "B", "C")]
 
@@ -144,7 +148,10 @@ def test_registry_single_class_predicate_also_sub():
 
 
 def test_registry_multi_class_predicate():
-    r = PredicateRegistry(match_instance("a"), match_instance("b"),)
+    r = PredicateRegistry(
+        match_instance("a"),
+        match_instance("b"),
+    )
 
     class A(object):
         pass
@@ -176,7 +183,10 @@ def test_registry_multi_class_predicate():
 
 
 def test_registry_multi_mixed_predicate_class_key():
-    r = PredicateRegistry(match_instance("a"), match_key("b"),)
+    r = PredicateRegistry(
+        match_instance("a"),
+        match_key("b"),
+    )
 
     class A(object):
         pass
@@ -203,7 +213,10 @@ def test_registry_multi_mixed_predicate_class_key():
 
 
 def test_registry_multi_mixed_predicate_key_class():
-    r = PredicateRegistry(match_key("a"), match_instance("b"),)
+    r = PredicateRegistry(
+        match_key("a"),
+        match_instance("b"),
+    )
 
     class B(object):
         pass

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,6 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Topic :: Software Development :: Libraries :: Python Modules",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34, py35, py36, py37, py38, pypy3, coverage, pep8, docs, perf
+envlist = py36, py37, py38, pypy3, coverage, pep8, docs, perf
 skipsdist = True
 skip_missing_interpreters = True
 
@@ -7,20 +7,20 @@ skip_missing_interpreters = True
 usedevelop = True
 extras = test
 
-commands = py.test {posargs}
+commands = pytest {posargs}
 
 [testenv:coverage]
 basepython = python3.7
 extras = test
          coverage
 
-commands = py.test --cov --cov-fail-under=100 {posargs}
+commands = pytest --cov --cov-fail-under=100 {posargs}
 
 [testenv:pep8]
 basepython = python3.7
 extras = pep8
 
-commands = flake8 reg *.py
+commands = flake8 .
            black --check .
 
 [testenv:docs]


### PR DESCRIPTION
This merge request updates the minimal Python version to 3.6 and adds 3.8.

It also adds the tools required to run the tests to list of dependencies as well fixes black and flake8 issues.

Fixes #61 